### PR TITLE
Use `pass_filenames: false` in `.pre-commit-hooks.yaml`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,6 +4,7 @@
   entry: hook-wrappers/post-checkout-wrapper
   # Since post-checkout doesn't operate on files, any hooks must set always_run
   always_run: true
+  pass_filenames: false
   stages: [post-checkout]
 
 - id: post-commit
@@ -12,6 +13,7 @@
   entry: hook-wrappers/post-commit-wrapper
   # Since post-commit does not operate on files, any hooks must set always_run
   always_run: true
+  pass_filenames: false
   stages: [post-commit]
 
 - id: post-merge
@@ -19,6 +21,7 @@
   language: script
   entry: hook-wrappers/post-merge-wrapper
   always_run: true
+  pass_filenames: false
   stages: [post-merge]
 
 - id: pre-push
@@ -26,4 +29,5 @@
   language: script
   entry: hook-wrappers/pre-push-wrapper
   always_run: true
+  pass_filenames: false
   stages: [push]


### PR DESCRIPTION
With this option, no filenames will be passed to the hooks, since they are not needed for the specific ones anyway.